### PR TITLE
default active

### DIFF
--- a/htdocs/app/code/community/Mgt/DeveloperToolbar/etc/config.xml
+++ b/htdocs/app/code/community/Mgt/DeveloperToolbar/etc/config.xml
@@ -63,7 +63,7 @@
                                 </config>
                             </children>
                         </system>
-                   </children>
+                    </children>
                 </admin>
             </resources>
         </acl>
@@ -93,4 +93,11 @@
             </updates>
         </layout>
     </frontend>
+    <default>
+        <mgt_developertoolbar>
+            <mgt_developertoolbar>
+                <active>1</active>
+            </mgt_developertoolbar>
+        </mgt_developertoolbar>
+    </default>
 </config>


### PR DESCRIPTION
This is a developer extension. Do you have the problem, that people install it on production environments?

If not, make it default active!
