### PR TITLE
check if toolbar is active before enabling Zend_Db_Profiler

### DIFF
--- a/htdocs/app/code/community/Mgt/DeveloperToolbar/Model/Resource.php
+++ b/htdocs/app/code/community/Mgt/DeveloperToolbar/Model/Resource.php
@@ -44,7 +44,12 @@ class Mgt_DeveloperToolbar_Model_Resource extends Mage_Core_Model_Resource
 
         $typeInstance = $this->getConnectionTypeInstance((string)$connConfig->type);
         $conn = $typeInstance->getConnection($connConfig);
-        $conn->getProfiler()->setEnabled(true);
+
+        $configPath = Mgt_DeveloperToolbar_Block_Toolbar::XML_PATH_MGT_DEVELOPERTOOLBAR_ACTIVE;
+        if ((int) Mage::getConfig()->getNode($configPath)) {
+            $conn->getProfiler()->setEnabled(true);
+        }
+
         if (method_exists($conn, 'setCacheAdapter')) {
             $conn->setCacheAdapter(Mage::app()->getCache());
         }


### PR DESCRIPTION
even if toolbar is disabled, currently Zend_Db_Profiler is getting enabled, which is especially bad for production and heavy DB operations such as re-indexing.
