### PR TITLE
[Bugfix] An error occurred during installation

### DIFF
--- a/src/app/code/Mgt/DeveloperToolbar/Model/Driver/Output/Zero.php
+++ b/src/app/code/Mgt/DeveloperToolbar/Model/Driver/Output/Zero.php
@@ -35,6 +35,14 @@ class Zero implements OutputInterface
     {
         try {
             $objectManager = ObjectManager::getInstance();
+            $objectManager->configure(
+                [
+                    'preferences' => [
+                        \Magento\Framework\App\Config\Scope\ReaderPoolInterface::class =>
+                            \Magento\Store\Model\Config\Reader\ReaderPool::class
+                    ]
+                ]
+            );
             
             $registry = $objectManager->get('\Magento\Framework\Registry');
             $config = $objectManager->get('\Mgt\DeveloperToolbar\Model\Config');


### PR DESCRIPTION
- bagfix for (Fatal error: Uncaught Error: Cannot instantiate interface Magento\Framework\App\Config\Scope\ReaderPoolInterface in ...\lib\internal\Magento\Framework\ObjectManager\Factory\Dynamic\Developer.php:73)
