### PR TITLE
[TASK] Removed Duplicate Router Entry

### DIFF
--- a/src/app/code/Mgt/DeveloperToolbar/etc/frontend/routes.xml
+++ b/src/app/code/Mgt/DeveloperToolbar/etc/frontend/routes.xml
@@ -4,8 +4,6 @@
         <route id="mgtdevelopertoolbar" frontName="mgtdevelopertoolbar">
             <module name="Mgt_DeveloperToolbar" />
         </route>
-    </router>
-    <router id="standard">
         <route id="mgtfeed" frontName="mgtfeed">
             <module name="Mgt_DeveloperToolbar" />
         </route>


### PR DESCRIPTION
The Router Entry with the id="standard" is superfluous and can be removed.
