### PR TITLE
Deprecated Functionality: Creation of dynamic property Mgt\\Developer…

### DIFF
--- a/src/app/code/Mgt/DeveloperToolbar/Model/Observer/DataCollector.php
+++ b/src/app/code/Mgt/DeveloperToolbar/Model/Observer/DataCollector.php
@@ -88,7 +88,7 @@ class DataCollector implements ObserverInterface
     /**
      * @var \Magento\Framework\Stdlib\CookieManagerInterface
      */
-    protected $cookiesManager;
+    protected $cookieManager;
     
     /**
      * @var \Magento\Framework\Event\ManagerInterface


### PR DESCRIPTION
…Toolbar\\Model\\Observer\\DataCollector::$cookieManager

`$cookieManager` is created dynamically, since the property was erronously called `$cookiesManager` (plural s). It is questionable if the dependency is needed at all, since it is not used.